### PR TITLE
Use correct 'Paws.coffee' name in require

### DIFF
--- a/Test/utility.tests.coffee
+++ b/Test/utility.tests.coffee
@@ -1,5 +1,5 @@
 `require = require('../Source/cov_require.js')(require)`
-paws = require "../Source/paws.coffee"
+paws = require "../Source/Paws.coffee"
 expect = require 'expect.js'
 
 describe "Paws' utilities:", ->


### PR DESCRIPTION
This was causing a `Cannot find module '../Source/paws.coffee'` error when running the tests on case-sensitive systems.
